### PR TITLE
Added resistance against public IP API endpoints returning bytes literal rather than string

### DIFF
--- a/octodns_ddns/__init__.py
+++ b/octodns_ddns/__init__.py
@@ -54,6 +54,8 @@ class DdnsSource(BaseSource):
 
         for _type in self.types:
             addr = self._get_addr(_type)
+            if isinstance(addr, bytes):
+                addr = addr.decode('utf-8')
             if addr:
                 record = Record.new(zone, self.id, {
                     'ttl': self.ttl,

--- a/octodns_ddns/__init__.py
+++ b/octodns_ddns/__init__.py
@@ -56,6 +56,7 @@ class DdnsSource(BaseSource):
             addr = self._get_addr(_type)
             if isinstance(addr, bytes):
                 addr = addr.decode('utf-8')
+                addr = addr.strip('\n')
             if addr:
                 record = Record.new(zone, self.id, {
                     'ttl': self.ttl,


### PR DESCRIPTION
I found that using the default url `https://api.ident.me/` for IP queries, it would fail every time, and never connect. I attempted to use a few other services, namely `https://www.ipify.org/` and `https://icanhazip.com/`, which both are functioning properly and returning my public address. I can see it in the debug output, however it was returning as a bytes literal object rather than string. I figure this can be easily mitigated by just checking to see if we are getting a bytes literal in the response and decoding it if it is.