### PR TITLE
Include populate lenient parameter

### DIFF
--- a/octodns_ddns/__init__.py
+++ b/octodns_ddns/__init__.py
@@ -61,7 +61,7 @@ class DdnsSource(BaseSource):
         self.log.info('_get_addr: type=%s is %s', _type, addr)
         return addr
 
-    def populate(self, zone, target=False):
+    def populate(self, zone, target=False, lenient=False):
         self.log.debug('populate: zone=%s', zone.name)
         before = len(zone.records)
 


### PR DESCRIPTION
Removes a warning from more recent versions of octodns, as in last 5 years :-)