### PR TITLE
Bump required octodns >= 1.5, address pending deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,5 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
-    # TODO: remove once octodns 2.0 has been released
-    'ignore:.*DEPRECATED.*2.0',
 ]
 pythonpath = "."

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         ),
         'test': tests_require,
     },
-    install_requires=('octodns>=0.9.14', 'requests>=2.27.0'),
+    install_requires=('octodns>=1.5.0', 'requests>=2.27.0'),
     license='MIT',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Address deprecations happening in upcoming octoDNS 2.x

/cc https://github.com/octodns/octodns/issues/1215 for tracking
