### PR TITLE
Update default backend to Ipify

### DIFF
--- a/.changelog/97ee44eaf08e4021943d3ededa36c824.md
+++ b/.changelog/97ee44eaf08e4021943d3ededa36c824.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Update default backend to Ipify

--- a/README.md
+++ b/README.md
@@ -88,9 +88,21 @@ can configure `urls` with `a` and/or `aaaa` with urls that return the address
 as the content of the response.
 
 ```yaml
-  dynamic:
-    class: octodns_ddns.DdnsSource
-    urls:
-      A: https://v4.ident.me/
-      AAAA: https://v6.ident.me/
+dynamic:
+  class: octodns_ddns.DdnsSource
+  urls:
+    # Defaults:
+    A: https://api.idify.org/
+    AAAA: https://api6.idify.org/
 ```
+
+#### Alternatives
+
+The following have been tested and confirmed to work as of the time they were added to this document.
+
+| Service                                | IPv4 URL                      | IPv6 URL                      |
+| :------------------------------------- | :---------------------------- | :---------------------------- |
+| [ipify.org](https://www.ipify.org)     | `https://api.ipify.org`       | `https://api6.ipify.org`      |
+| [icanhazip.com](https://icanhazip.com) | `https://ipv4.icanhazip.com`  | `https://ipv6.icanhazip.com`  |
+| [ipinfo.io](https://ipinfo.io)         | `https://v4.api.ipinfo.io/ip` | `https://v6.api.ipinfo.io/ip` |
+| [ident.me](https://ident.me)           | `https://v4.ident.me/`        | `https://v6.ident.me/`        |

--- a/octodns_ddns/__init__.py
+++ b/octodns_ddns/__init__.py
@@ -37,8 +37,8 @@ class DdnsSource(BaseSource):
         self.types = types
         self.ttl = ttl
         self.urls = {
-            'A': urls.get('A', 'https://v4.ident.me/'),
-            'AAAA': urls.get('AAAA', 'https://v6.ident.me/'),
+            'A': urls.get('A', 'https://api.ipify.org/'),
+            'AAAA': urls.get('AAAA', 'https://api6.ipify.org/'),
         }
 
         self._sess = Session()

--- a/tests/test_octodns_source_ddns.py
+++ b/tests/test_octodns_source_ddns.py
@@ -39,7 +39,7 @@ class TestDdnsSource(TestCase):
         self.assertEqual([aaaa_value], aaaa.values)
 
         mock.assert_has_calls(
-            [call('https://v4.ident.me/'), call('https://v6.ident.me/')]
+            [call('https://api.ipify.org/'), call('https://api6.ipify.org/')]
         )
 
     @patch('requests.Session.get')
@@ -79,7 +79,7 @@ class TestDdnsSource(TestCase):
         DdnsSource('dynamic', types=('A',)).populate(zone)
         self.assertEqual(1, len(zone.records))
 
-        mock.assert_has_calls([call('https://v4.ident.me/')])
+        mock.assert_has_calls([call('https://api.ipify.org/')])
         mock.assert_called_once()
 
     @patch('requests.Session.get')
@@ -91,7 +91,7 @@ class TestDdnsSource(TestCase):
         DdnsSource('dynamic', types=('AAAA',)).populate(zone)
         self.assertEqual(1, len(zone.records))
 
-        mock.assert_has_calls([call('https://v6.ident.me/')])
+        mock.assert_has_calls([call('https://api6.ipify.org/')])
         mock.assert_called_once()
 
     @patch('requests.Session.get')


### PR DESCRIPTION
New default is OSS and community funded so it seemed like a reasonable place to point. Lists out a few options in the bottom of the README

/cc Fixes https://github.com/octodns/octodns-ddns/issues/63