### PR TITLE
Version 0.3.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/2c8a9cd976d648aba663d60689a7a56a.md
+++ b/.changelog/2c8a9cd976d648aba663d60689a7a56a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/87d3d1d120c249d29d97fa867123966a.md
+++ b/.changelog/87d3d1d120c249d29d97fa867123966a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/88a16d8a85694917b1df04cfe63718b2.md
+++ b/.changelog/88a16d8a85694917b1df04cfe63718b2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/97ee44eaf08e4021943d3ededa36c824.md
+++ b/.changelog/97ee44eaf08e4021943d3ededa36c824.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Update default backend to Ipify

--- a/.changelog/a542d2b200534151b82fb185669b87b1.md
+++ b/.changelog/a542d2b200534151b82fb185669b87b1.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/fbcf472acce94e62be5cec3fb1d8e5e2.md
+++ b/.changelog/fbcf472acce94e62be5cec3fb1d8e5e2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0 - 2026-02-13
+
+Minor:
+* Update default backend to Ipify - [#64](https://github.com/octodns/octodns-ddns/pull/64)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#53](https://github.com/octodns/octodns-ddns/pull/53)
+
 ## TODO: v0.2.1 - 2022-02-07 - Modernize w/octodns-template
 
 * Fix an encoding error that prevented py3 response from being a valid IP

--- a/octodns_ddns/__init__.py
+++ b/octodns_ddns/__init__.py
@@ -23,7 +23,7 @@ from octodns.record import Record
 from octodns.source.base import BaseSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.2.1'
+__version__ = __VERSION__ = '0.3.0'
 
 
 class DdnsSource(BaseSource):


### PR DESCRIPTION
## 0.3.0 - 2026-02-13

Minor:
* Update default backend to Ipify - [#64](https://github.com/octodns/octodns-ddns/pull/64)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#53](https://github.com/octodns/octodns-ddns/pull/53)

